### PR TITLE
Add tablet pen button trigger

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -74,6 +74,9 @@ void gebaar::config::Config::load_config()
             settings.pinch_threshold = config->get_qualified_as<double>("pinch.settings.threshold").value_or(0.25);
             settings.pinch_one_shot = config->get_qualified_as<bool>("pinch.settings.one_shot").value_or(false);
 
+            /* pen button settings */
+            pen_button_commands = *config->get_qualified_as<std::string>("pen_button.commands.command");
+            settings.pen_button_trigger_on_release = config->get_qualified_as<bool>("pen_button.settings.trigger_on_release").value_or(true);
 
             loaded = true;
         }

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -41,12 +41,14 @@ namespace gebaar::config {
           bool swipe_one_shot;
           double swipe_threshold;
           bool swipe_trigger_on_release;
+          bool pen_button_trigger_on_release;
         } settings;
 
         enum pinch {PINCH_IN, PINCH_OUT};
         std::string swipe_three_commands[10];
         std::string swipe_four_commands[10];
         std::string pinch_commands[10];
+        std::string pen_button_commands;
 
     private:
 

--- a/src/io/input.h
+++ b/src/io/input.h
@@ -47,6 +47,10 @@ namespace gebaar::io {
         int step;
     };
 
+    struct pen_button_event {
+        bool state;
+    };
+
     class Input {
     public:
         Input(std::shared_ptr<gebaar::config::Config> const& config_ptr);
@@ -66,6 +70,7 @@ namespace gebaar::io {
 
         struct gesture_swipe_event gesture_swipe_event;
         struct gesture_pinch_event gesture_pinch_event;
+        struct pen_button_event pen_button_event;
 
         bool initialize_context();
 
@@ -118,6 +123,13 @@ namespace gebaar::io {
         void handle_continouos_pinch(double new_scale);
 
         void handle_pinch_event(libinput_event_gesture* gev, bool begin);
+
+
+        void trigger_pen_button_command();
+
+        void handle_pen_button_event_without_coords(libinput_event_tablet_tool* ttev);
+
+        void reset_pen_button_event();
 
     };
 }


### PR DESCRIPTION
This adds  the stylus pen button functionality using:
```
[settings.pen_button]
trigger_on_release = true

[pen_button.commands]
command = 'evemu-shift-U.sh'
```